### PR TITLE
Update proxyquireify to work with latest browserify

### DIFF
--- a/lib/hack-prelude.js
+++ b/lib/hack-prelude.js
@@ -1,6 +1,6 @@
 'use strict';
 var fs              =  require('fs')
-  , preludePath     =  require.resolve('browserify/node_modules/browser-pack/prelude')
+  , preludePath     =  require.resolve('browserify/node_modules/browser-pack/_prelude')
   , preludeHackPath =  require.resolve('./prelude')
   , hack            =  fs.readFileSync(preludeHackPath, 'utf-8');
 
@@ -15,7 +15,7 @@ fs.readFileSync = function (path) {
   return fs_readFileSync.apply(null, args);
 };
 
-exports.browserify = function (files) { 
+exports.browserify = function (files) {
   delete require.cache[require.resolve('browserify')];
   delete require.cache[require.resolve('browserify/node_modules/browser-pack')];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxyquireify",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Proxies browserify's require in order to allow overriding dependencies during testing.",
   "main": "proxyquireify.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "devDependencies": {
     "tape": "~0.3.2",
     "mold-source-map": "~0.2.0",
-    "browserify": "~2.10.2"
+    "browserify": "~3.38.0"
   },
   "keywords": [
     "require",


### PR DESCRIPTION
The current version of browser-pack/browserify uses a different path for loading the prelude causing proxyquirefy's hacked prelude to never be loaded.
