### PR TITLE
Fix build script in example

### DIFF
--- a/examples/foobar/build.js
+++ b/examples/foobar/build.js
@@ -3,8 +3,8 @@ var fs         = require('fs')
   , browserify = require('browserify')
   ;
 
-browserify()
+browserify({ debug: true })
   .plugin(proxyquire.plugin)
   .require(require.resolve('./test'), { entry: true })
-  .bundle({ debug: true })
+  .bundle()
   .pipe(fs.createWriteStream(__dirname + '/bundle.js'));


### PR DESCRIPTION
Hi, I'm trying to foobar example and get an error:

```
> foobar@0.0.0 test /Users/azu/workspace/toybox/proxyquireify/examples/foobar
> node build && open index.html


/Users/azu/workspace/toybox/proxyquireify/node_modules/browserify/index.js:456
        throw new Error(
              ^
Error: bundle() no longer accepts option arguments.
Move all option arguments to the browserify() constructor.
    at Browserify.bundle (/Users/azu/workspace/toybox/proxyquireify/node_modules/browserify/index.js:456:15)
    at Object.<anonymous> (/Users/azu/workspace/toybox/proxyquireify/examples/foobar/build.js:9:4)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:906:3
```

bundle() no longer accepts option arguments with browserify 5.0.
- https://github.com/substack/node-browserify/blob/master/doc/changelog/5_0.markdown#bundle

This pull request fixes `build.js`.
