### PR TITLE
Replace prelude in pipeline when reset is called

### DIFF
--- a/lib/replace-prelude.js
+++ b/lib/replace-prelude.js
@@ -10,17 +10,20 @@ var prelude = fs.readFileSync(preludePath, 'utf8');
 
 // This plugin replaces the prelude and adds a transform
 var plugin = exports.plugin = function (bfy, opts) {
-  var packOpts = {
-    raw: true, // Added in regular Browserifiy as well
-    preludePath: preludePath,
-    prelude: prelude
-  };
+  var replacePrelude = function() {
+    var packOpts = {
+      raw: true, // Added in regular Browserifiy as well
+      preludePath: preludePath,
+      prelude: prelude
+    };
 
-  var packer = bpack(xtend(bfy._options, packOpts));
-  // Replace the 'pack' step with the new browser-pack instance
-  bfy.pipeline.splice('pack', 1, packer);
-
+    var packer = bpack(xtend(bfy._options, packOpts));
+    // Replace the 'pack' step with the new browser-pack instance
+    bfy.pipeline.splice('pack', 1, packer);
+  }
   bfy.transform(require('./transform'));
+  bfy.on('reset', replacePrelude);
+  replacePrelude();
 };
 
 // Maintain support for the old interface


### PR DESCRIPTION
This pull request should enable proxyquireify to work when bundle() is called multiple times on the same browserify instance. This is useful e.g. if you are using watchify to take advantage of its caching facilities for faster builds.

``` js
var b = browserify(entryPoint, watchify.args);

b = watchify(b);
b.plugin(proxyquireify.plugin)
b.bundle()

b.on('update', b.bundle);
```

When watchify fires the update event, b.bundle() calls b.reset() which creates a new pipeline. This new pipeline does not contain the browser-pack with the modified prelude that proxyquireify spliced in when the plugin was registered. So all calls to bundle after the first use the standard browserify prelude instead of proxyquireify's.

This pull request splices the proxyquireify browser-pack into the pipeline each time the reset event is emitted by browserify.
