### PR TITLE
Avoid using unsupported methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var keys = require('amp-keys');
+var each = require('amp-each');
+
 function ProxyquireifyError(msg) {
   this.name = 'ProxyquireifyError';
   Error.captureStackTrace(this, ProxyquireifyError);
@@ -40,11 +43,11 @@ function reset() {
 }
 
 function fillMissingKeys(mdl, original) {
-  Object.keys(original).forEach(function (key) {
+  each(keys(original), function (key) {
     if (!mdl[key]) mdl[key] = original[key];
   });
   if (typeof mdl === 'function' && typeof original === 'function') {
-      Object.keys(original.prototype).forEach(function (key) {
+      each(keys(original.prototype), function (key) {
           if (!mdl.prototype[key]) mdl.prototype[key] = original.prototype[key];
       });
   }

--- a/lib/prelude.js
+++ b/lib/prelude.js
@@ -11,13 +11,43 @@
     var previousRequire = typeof require == "function" && require;
 
     function findProxyquireifyName() {
-        var deps = Object.keys(modules)
-            .map(function (k) { return modules[k][1]; });
+        var deps = map(keys(modules), function (k) { return modules[k][1]; });
 
         for (var i = 0; i < deps.length; i++) {
             var pq = deps[i]['proxyquireify'];
             if (pq) return pq;
         }
+    }
+
+    function forEach(obj, it) {
+        if (obj instanceof Array) {
+            for (var i = 0; i < obj.length; i++) {
+                it(obj[i], i);
+            }
+        } else {
+            for (var k in obj) {
+                if (obj.hasOwnProperty(k)) {
+                    it(obj[k], k);
+                }
+            }
+        }
+        return obj;
+    }
+
+    function map(list, it) {
+        var out = [];
+        forEach(list, function (item) {
+            out.push(it(item))
+        })
+        return out;
+    }
+
+    function keys(obj) {
+        var keyList = [];
+        forEach(obj, function (item, key) {
+            keyList.push(key);
+        })
+        return keyList;
     }
 
     var proxyquireifyName = findProxyquireifyName();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "homepage": "https://github.com/thlorenz/proxyquireify",
   "dependencies": {
+    "amp-each": "^1.0.1",
+    "amp-keys": "^1.0.1",
     "browser-pack": "^3.0.0",
     "detective": "~3.1.0",
     "has-require": "^1.1.0",


### PR DESCRIPTION
Object.keys and Array.prototype.map are not supported in older browsers (IE8 and lower)