### PR TITLE
Use fill-keys to copy properties from source to stub

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var fillMissingKeys = require('fill-keys');
+
 function ProxyquireifyError(msg) {
   this.name = 'ProxyquireifyError';
   Error.captureStackTrace(this, ProxyquireifyError);
@@ -37,19 +39,6 @@ function stub(stubs_) {
 function reset() {
   stubs = undefined;
   module.exports._cache = null;
-}
-
-function fillMissingKeys(mdl, original) {
-  Object.keys(original).forEach(function (key) {
-    if (!mdl[key]) mdl[key] = original[key];
-  });
-  if (typeof mdl === 'function' && typeof original === 'function') {
-      Object.keys(original.prototype).forEach(function (key) {
-          if (!mdl.prototype[key]) mdl.prototype[key] = original.prototype[key];
-      });
-  }
-
-  return mdl;
 }
 
 var proxyquire = module.exports = function (require_) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "browser-pack": "^3.0.0",
     "detective": "~3.1.0",
+    "fill-keys": "^1.0.0",
     "has-require": "^1.1.0",
     "through": "~2.2.7",
     "xtend": "^3.0.0"


### PR DESCRIPTION
* Aligns p-ify with proxyquire
* Correctly handles falsy stub values

Closes #32 

Ready for review @thlorenz 