### PR TITLE
Fix client side integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
-  - 0.10
+  - '0.10'
+  - '0.12'
+  - iojs
 before_install:
   - npm install -g npm

--- a/test/clientside/argument-validation.js
+++ b/test/clientside/argument-validation.js
@@ -1,8 +1,7 @@
 'use strict';
 /*jshint asi: true, browser: true */
 
-var test       =  require('tape')
-  , proxyquire =  require('proxyquireify')(require)
+var proxyquire =  require('proxyquireify')(require)
   , bar = { bar: function () { return 'bar'; } }
 
 function throws(t, action, regex, desc) {

--- a/test/clientside/independent-overrides.js
+++ b/test/clientside/independent-overrides.js
@@ -1,8 +1,7 @@
 'use strict';
 /*jshint asi: true, browser: true */
 
-var test       =  require('tape')
-  , proxyquire =  require('proxyquireify')(require)
+var proxyquire =  require('proxyquireify')(require)
   , stats      =  require('../fixtures/stats')
   , barber     =  { bar: function () { return 'barber'; } }
   ;

--- a/test/clientside/manipulating-overrides.js
+++ b/test/clientside/manipulating-overrides.js
@@ -1,8 +1,7 @@
 'use strict';
 /*jshint asi: true, browser: true */
 
-var test       =  require('tape')
-  , proxyquire =  require('proxyquireify')(require)
+var proxyquire =  require('proxyquireify')(require)
   , barber     =  { bar: function () { return 'barber'; } }
   ;
 

--- a/test/clientside/noCallThru.js
+++ b/test/clientside/noCallThru.js
@@ -1,8 +1,7 @@
 'use strict';
 /*jshint asi: true, browser: true */
 
-var test       =  require('tape')
-  , proxyquire =  require('proxyquireify')(require)
+var proxyquire =  require('proxyquireify')(require)
   , file = '/folder/test.ext'
   ;
 

--- a/test/clientside/run.js
+++ b/test/clientside/run.js
@@ -4,6 +4,7 @@
 var browserify =  require('browserify');
 var proxyquire =  require('../..');
 var vm         =  require('vm');
+var test       =  require('tape');
 
 function run(name) {
 
@@ -18,14 +19,9 @@ function run(name) {
     .on('data', function (data) { src += data })
     .on('end', function () {
       // require('fs').writeFileSync(require('path').join(__dirname, '../../examples/bundle.js'), src, 'utf-8')
-
-      vm.runInNewContext(src, { 
-          setTimeout    :  setTimeout
-        , clearInterval :  clearInterval
-        , clearTimeout  :  clearTimeout
-        , console       :  console
-        , window        :  {}
-      } );
+      test(name, function(t) {
+        vm.runInNewContext(src, { test: t.test.bind(t), window: {} });
+      })
   });
 }
 


### PR DESCRIPTION
As discussed in #33

Previously:

* Pass in every global tape depends on
* Create a new test runner for every suite

Now:

* Create a single runner and pass a "test" global to every test
* Use named, nested tests for more readable output

Bonus:

* Tests pass on iojs!
* Add 0.12 and iojs to Travis