### PR TITLE
Do not execute required mock

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -8,8 +8,8 @@ var through          =  require('through')
 function requireDependencies(src) {
   var deps = findDependencies(src);
   if (!deps.length) return '';
-  return '/* proxyquireify injected requires to make browserify include dependencies in the bundle */;' +
-    requireDeps(deps);
+  return '/* proxyquireify injected requires to make browserify include dependencies in the bundle */ /* istanbul ignore next */; (function __makeBrowserifyIncludeModule__() { ' +
+    requireDeps(deps) + '});';
 }
 
 module.exports = function (file) {

--- a/test/clientside/independent-overrides.js
+++ b/test/clientside/independent-overrides.js
@@ -10,7 +10,7 @@ var foober =  proxyquire('../fixtures/foo', { './bar': barber });
 var foo    =  proxyquire('../fixtures/foo', { './bar': { } });
 
 test('\noverriding bar.bar for foober but not for foo', function (t) {
-  t.equal(window.foostats.fooRequires(), 3, 'foo is required three times since one for each test and one for require detective')
+  t.equal(window.foostats.fooRequires(), 2, 'foo is required three times since one for each test and one for require detective')
   t.equal(foo.bigBar(), 'BAR', 'foo.bigBar == BAR')  
   t.equal(foober.bigBar(), 'BARBER', 'foober.bigBar == BARBER');
 

--- a/test/clientside/run.js
+++ b/test/clientside/run.js
@@ -6,26 +6,56 @@ var proxyquire =  require('../..');
 var vm         =  require('vm');
 var test       =  require('tape');
 
-function run(name) {
-
-  var src = '';
-
+function compile(name, cb) {
   browserify()
     .plugin(proxyquire.plugin)
     .require(require.resolve('../..'), { expose: 'proxyquireify' })
     .require(require.resolve('./' + name), { entry: true })
-    .bundle()
-    .on('error',  function error(err) { console.error(err); process.exit(1); })
-    .on('data', function (data) { src += data })
-    .on('end', function () {
-      // require('fs').writeFileSync(require('path').join(__dirname, '../../examples/bundle.js'), src, 'utf-8')
-      test(name, function(t) {
-        vm.runInNewContext(src, { test: t.test.bind(t), window: {} });
-      })
+    .bundle(function (err, src) {
+      if (err) return cb(err);
+      cb(null, { src: src, name: name });
+    });
+}
+
+// run the compiled tests in a new context
+function run(args) {
+  var name = args.name;
+  var src  = args.src;
+
+  test(name, function(t) {
+    vm.runInNewContext(src, { test: t.test.bind(t), window: {} });
+  })
+}
+
+// compile all tests and fire a callback when the
+// all code is compiled and ready to be executed
+function compileAll(tests, cb) {
+  var results = [];
+  var pending = tests.length;
+  tests.forEach(function (name, idx) {
+    compile(name, function (err, result) {
+      if (err) return cb(err);
+
+      results[idx] = result;
+      if (--pending === 0) {
+        cb(null, results);
+      }
+    });
   });
 }
 
-run('independent-overrides')
-run('manipulating-overrides')
-run('noCallThru')
-run('argument-validation')
+var clientTests = [
+    'independent-overrides'
+  , 'manipulating-overrides'
+  , 'noCallThru'
+  , 'argument-validation'
+];
+
+compileAll(clientTests, function (err, results) {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+    return;
+  }
+  results.forEach(run);
+});


### PR DESCRIPTION
Hi guys this is the improvement proposed as part of https://github.com/thlorenz/proxyquireify/issues/38

Couple of notes.

- the magic just wraps the call to require with an anonymous function. Since it is not executed it prevents double calls to require that were happening before.
- the tests were consistently failing, some sort of race condition maybe. I just solved it splitting the problematic test into its own module and launching it after the other tests. Would be really nice to figure it out what went wrong, but at least this helps pass the tests for now 