### PR TITLE
Mock requires inside functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ var proxyquire = module.exports = function (require_) {
 
   reset();
 
-  return function(request, stubs) {
+  var prxCall = function(request, stubs) {
 
     validateArguments(request, stubs);
 
@@ -58,11 +58,15 @@ var proxyquire = module.exports = function (require_) {
     // when stub require is invoked by the module under test it will find the stubs here
     stub(stubs);
     var dep = require_(request);
-    reset();
+    //reset();
 
     return dep;
   };
+
+  prxCall.reset = reset;
+  return prxCall;
 };
+
 
 // Start with the default cache
 proxyquire._cache = null;

--- a/test/clientside/require-in-method.js
+++ b/test/clientside/require-in-method.js
@@ -1,0 +1,14 @@
+'use strict';
+/*jshint asi: true, browser: true */
+
+var proxyquire =  require('proxyquireify')(require)
+  , barber     =  { bar: function () { return 'barber'; } }
+  ;
+
+test('\noverriding dep with stub when original require is done inside a method', function (t) {
+
+  var foober = proxyquire('../fixtures/require-in-method', { './bar': barber }).create();
+  t.equal(foober.bar(), 'barber', 'returns the modified value')
+
+  t.end()
+})

--- a/test/clientside/run.js
+++ b/test/clientside/run.js
@@ -49,6 +49,7 @@ var clientTests = [
   , 'manipulating-overrides'
   , 'noCallThru'
   , 'argument-validation'
+  , 'require-in-method'
 ];
 
 compileAll(clientTests, function (err, results) {

--- a/test/fixtures/require-in-method.js
+++ b/test/fixtures/require-in-method.js
@@ -1,0 +1,9 @@
+module.exports = {
+  create: function () {
+    return {
+      bar: function () {
+        return require('./bar').bar();
+      }
+    };
+  }
+};


### PR DESCRIPTION
NOTE: stub and cache need to manually be cleared.

```javascript
var proxiquire = require('proxiquireify')(require);

var mod = proxiquire('./path/to/dep', { 'bar': { bar: function () { return 'bar'; } } });

// later in the code
proxiquire.reset(); // to destroy the stub cache and module cache

```