### PR TITLE
Fix browserify 'pack' pipeline replacement

### DIFF
--- a/lib/replace-prelude.js
+++ b/lib/replace-prelude.js
@@ -19,8 +19,8 @@ var plugin = exports.plugin = function (bfy, opts) {
 
     // browserify sets "hasExports" directly on bfy._bpack
     bfy._bpack = bpack(xtend(bfy._options, packOpts, {hasExports: bfy._bpack.hasExports}));
-    // Replace the 'pack' pipeline step with the new browser-pack instance
-    bfy.pipeline.splice('pack', 1, bfy._bpack);
+    // Replace the 'pack' sub-pipeline with the new browser-pack instance
+    bfy.pipeline.get('pack').splice(0, 1, bfy._bpack);
   }
 
   bfy.transform(require('./transform'));


### PR DESCRIPTION
Instead of replacing the 'pack' pipeline (and losing the label), this fix replaces the browser-pack stream in 'pack' sub-pipeline. This leaves the label and allows for later `bfy.pipeline.get('pack')` calls.
One example of such call happens in [watchify](https://github.com/substack/watchify) 3.6.1, which without this fix fails with proxyquire-universal plugin (https://github.com/substack/watchify/commit/b23c9c9f88c228b8ad26f86e49007da1edb1c287?diff=unified).