### PR TITLE
Match proxyquire behavior for falsy / null stubs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fillMissingKeys = require('fill-keys');
+var moduleNotFoundError = require('module-not-found-error');
 
 function ProxyquireifyError(msg) {
   this.name = 'ProxyquireifyError';
@@ -72,11 +73,11 @@ proxyquire._proxy = function (require_, request) {
     return require_(request);
   }
 
-  if (!stubs) return original();
+  if (!stubs || !stubs.hasOwnProperty(request)) return original();
 
   var stub = stubs[request];
 
-  if (!stub) return original();
+  if (stub === null) throw moduleNotFoundError(request)
 
   var stubWideNoCallThru = !!stubs['@noCallThru'] && stub['@noCallThru'] !== false;
   var noCallThru = stubWideNoCallThru || !!stub['@noCallThru'];

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "detective": "~3.1.0",
     "fill-keys": "^1.0.0",
     "has-require": "^1.1.0",
+    "module-not-found-error": "~1.0.1",
     "require-deps": "~1.0.1",
     "through": "~2.2.7",
     "xtend": "^3.0.0"

--- a/test/clientside/falsy.js
+++ b/test/clientside/falsy.js
@@ -1,0 +1,25 @@
+'use strict';
+/*jshint asi: true, browser: true */
+
+var proxyquire = require('proxyquireify')(require)
+
+test('\nreturns original value with no stub', function (t) {
+  var value = proxyquire('../fixtures/value', {})
+  t.equals(value, true)
+  t.end()
+})
+
+test('overriding dep with a false value', function (t) {
+  var value = proxyquire('../fixtures/value', { './true': false })
+  t.equals(value, false)
+  t.end()
+})
+
+test('throws with a null value', function (t) {
+  t.throws(load, /cannot find module/)
+  t.end()
+
+  function load () {
+  	proxyquire('../fixtures/value', { './true': null })
+  }
+})

--- a/test/clientside/run.js
+++ b/test/clientside/run.js
@@ -49,6 +49,7 @@ var clientTests = [
   , 'manipulating-overrides'
   , 'noCallThru'
   , 'argument-validation'
+  , 'falsy'
 ];
 
 compileAll(clientTests, function (err, results) {

--- a/test/fixtures/true.js
+++ b/test/fixtures/true.js
@@ -1,0 +1,1 @@
+module.exports = true

--- a/test/fixtures/value.js
+++ b/test/fixtures/value.js
@@ -1,0 +1,1 @@
+module.exports = require('./true')


### PR DESCRIPTION
* Falsy is allowed
* `null` is a module not found err

@thlorenz Will defer to you on how to version this. This behavior was never document on the pq-ify side.