### PR TITLE
Fix markup in example html

### DIFF
--- a/examples/foobar/index.html
+++ b/examples/foobar/index.html
@@ -4,7 +4,7 @@
   <meta charset=utf-8 />
   <title>foobar</title>
   <script type="text/javascript" src="./bundle.js"></script>
-</head
+</head>
 <body>
 <h2>proxyquireify - foobar test page</h2> 
 <p>It should say "schokolade ist wirklich wunderbar" in the console</p>


### PR DESCRIPTION
The head tag was missing its closing '>'
