### PR TITLE
Changing version of detective module

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/thlorenz/proxyquireify",
   "dependencies": {
     "browser-pack": "^6.0.0",
-    "detective": "~3.1.0",
+    "detective": "~4.1.0",
     "fill-keys": "^1.0.0",
     "has-require": "^1.1.0",
     "module-not-found-error": "~1.0.1",


### PR DESCRIPTION
Hello,
Would it be possible for proxyquireify to use detective version ~4.1.0? It has a dependency on esprima-fb which is causing build failures due to the metadata discrepancy in NPM. All the tests are passing with detective version up to 4.1.0. 
